### PR TITLE
Implemented tiebreaker ordering for identical intiative counts. 

### DIFF
--- a/NethysBot/Models/Battle.cs
+++ b/NethysBot/Models/Battle.cs
@@ -22,6 +22,23 @@ namespace NethysBot.Models
 	{
 		public string Name { get; set; }
 		public float Initiative { get; set; }
+		public int TiebreakerOrder { get; set; }
 		public ulong Player { get; set; }
+
+		public string InitiativeReadout
+		{
+			get
+			{
+				if(TiebreakerOrder == -1)
+				{
+					return Initiative.ToString();
+				}
+				else
+				{
+					return Initiative.ToString() + "-" + TiebreakerOrder.ToString();
+				} 
+					
+			}
+		}
 	}
 }


### PR DESCRIPTION
Syntax is [Initiative] <Ranking>, so if Alice & Bob both have 30 initiative, but Alice goes first, she'd input "!initiative 30 1" and Bob would input "!initiative 30 2". The default is "0". If the Tiebreaker order is zero, it is not displayed in the initiative tracking. (Because ints default to zero, all existing combats will not show the extra value)

Also tweaked !initiative [skill_name] to roll perception if someone types out "perception", rather than giving a misleading error message about not having a skill with that name.