### PR TITLE
Caster Duration fix and added targeting keywords.

### DIFF
--- a/NethysBot/Models/Battle.cs
+++ b/NethysBot/Models/Battle.cs
@@ -30,6 +30,9 @@ namespace NethysBot.Models
 
 	public struct BattleEffect
 	{
+		public const string AllPlayers = "players";
+		public const string AllNpcs = "npcs";
+
 		public string Name { get; set; }
 		public int Duration { get; set; }
 		public string HostCharacter { get; set; }


### PR DESCRIPTION
- When the current player uses !AddEffect, the intended behavior was …"End of Next [Duration] Turns", which is [Duration] + 1 rounds for the effect's creator (assuming they affect themselves) and [Duration] rounds for everyone else. Buffing now works as expected in this scenario.

- Fixed a null pointer when !encounter was used with active effects but before the encounter had been started
- Added in "Players" and "NPCs" keywords for !AddEffect. When "Players" is used, it will automatically target all non-director participants. When "NPCs" is used, it will automatically target all director-owned participants. "Players" and "NPCs" otherwise behave as normal targets -- e.g. "Steve" "Carl" "NPCs" will target Steve, Carl, and all director-owned participants.